### PR TITLE
Avoid missing maxres thumbnail

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 click==7.1.2
-croniter==0.3.35
-cryptography==3.2
+croniter==0.3.36
+cryptography==3.2.1
 django-crispy-forms==1.9.2
 django-environ==0.4.5
 django-model-utils==4.0.0
@@ -17,7 +17,7 @@ django==2.2.16
 djangorestframework==3.12.1
 github3.py==1.3.0
 google-api-python-client==1.12.5
-google-auth==1.22.1
+google-auth==1.23.0
 google-auth-httplib2==0.0.4
 honcho==1.0.1
 httplib2==0.18.1
@@ -28,11 +28,11 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20
 python-dateutil==2.8.1
-pytz==2020.1
+pytz==2020.4
 redis==3.5.3
 requests==2.24.0
 rsa==4.6
-sentry-sdk==0.19.1
+sentry-sdk==0.19.2
 six==1.15.0
 sqlparse==0.4.1
 uritemplate==3.0.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,4 +3,4 @@
 
 django-debug-toolbar==3.1.1
 django-extensions==3.0.9
-Sphinx==3.2.1
+Sphinx==3.3.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,5 +6,5 @@ django-anymail==8.1
 django-defender==0.8.0
 django-storages-redux==1.3.3
 gunicorn==20.0.4
-newrelic==5.22.0.151
+newrelic==5.22.1.152
 raven==6.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,10 +7,10 @@ coveralls==2.1.2
 django-test-plus==1.4.0
 factory-boy==3.1.0
 flake8==3.8.4
-pytest==6.1.1
+pytest==6.1.2
 pytest-django==4.1.0
 pytest-factoryboy==2.0.3
 pytest-mock==3.3.1
 pytest-tap==3.1
-regex==2020.10.23
+regex==2020.10.28
 responses==0.12.0

--- a/statusite/youtube/models.py
+++ b/statusite/youtube/models.py
@@ -39,7 +39,7 @@ class Playlist(models.Model):
         # Make sure maxres thumbail is present for each item,
         # by copying the default thumbnail if necessary.
         for item in results_playlistItems["items"]:
-            thumbnails = item["snippet"]["thumbnails"]
+            thumbnails = item.get("snippet", {}).get("thumbnails", {})
             if "maxres" not in thumbnails and "default" in thumbnails:
                 thumbnails["maxres"] = thumbnails["default"]
 

--- a/statusite/youtube/models.py
+++ b/statusite/youtube/models.py
@@ -35,5 +35,13 @@ class Playlist(models.Model):
             )
             .execute()
         )
+
+        # Make sure maxres thumbail is present for each item,
+        # by copying the default thumbnail if necessary.
+        for item in results_playlistItems["items"]:
+            thumbnails = item["snippet"]["thumbnails"]
+            if "maxres" not in thumbnails and "default" in thumbnails:
+                thumbnails["maxres"] = thumbnails["default"]
+
         self.json_str = json.dumps(results_playlistItems, default=json_serial)
         self.save()

--- a/statusite/youtube/tests/test_models.py
+++ b/statusite/youtube/tests/test_models.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from unittest import mock
+import json
 
 import pytest
-import pytz
 
 from statusite.youtube.models import Playlist, json_serial
 
@@ -21,13 +21,21 @@ class TestPlaylist:
         }
         youtube_api.playlistItems.return_value.list.return_value.execute.return_value = {
             "items": [
-                {"snippet": {"title": "Item 1", "publishedAt": datetime(2019, 6, 17)}}
+                {
+                    "snippet": {
+                        "title": "Item 1",
+                        "publishedAt": datetime(2019, 6, 17),
+                        "thumbnails": {"default": {"url": "bogus"}},
+                    }
+                }
             ]
         }
         playlist = playlist_factory()
         playlist.reload()
 
         assert playlist.title == "Playlist Title"
+        result = json.loads(playlist.json_str)
+        assert "maxres" in result["items"][0]["snippet"]["thumbnails"]
 
     def test_json_serial_unknown_type(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Sometimes the youtube API doesn't supply a maxres thumbnail for playlist items. But the NPSP Getting Started page expects there to be one. This fills one in by copying the default thumbnail if necessary.

Also update dependencies while I'm in here.